### PR TITLE
fix selection for search with last state

### DIFF
--- a/src/floatSearchIndex.ts
+++ b/src/floatSearchIndex.ts
@@ -468,7 +468,7 @@ class FloatSearchModal extends Modal {
 
 		setTimeout(async ()=>{
 			await this.searchLeaf.view.setState(this.state, true);
-			this.state?.current ? (this.searchLeaf.view as SearchView).searchComponent.inputEl.setSelectionRange(0, 0) : (this.searchLeaf.view as SearchView).searchComponent.inputEl.setSelectionRange(this.state?.query?.length, this.state?.query?.length);
+			this.state?.current ? (this.searchLeaf.view as SearchView).searchComponent.inputEl.setSelectionRange(0, 0) : (this.searchLeaf.view as SearchView).searchComponent.inputEl.setSelectionRange(0, this.state?.query?.length);
 		}, 0);
 
 		return;


### PR DESCRIPTION
This will preselect the last search query when opening the modal dialog using the command `Search Obsidian Globally (With Last State)`. It allows to quickly type another search query without the need to delete the remembered text while still maintaining the previous behavior.

It's a well-known behavior from other search dialogs remembering the last state, such as Spotlight on macOS.